### PR TITLE
Remove Composer autoloader from phpstan.neon

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,7 +2,6 @@ parameters:
     phpVersion: 70329
     level: 5
     bootstrapFiles:
-        - vendor/autoload.php
         - vendor/php-stubs/woocommerce-stubs/woocommerce-stubs.php
     paths:
         - source


### PR DESCRIPTION
PHPStan automatically loads this autoloader.
